### PR TITLE
docs: complete install guide

### DIFF
--- a/docs/langs/en/guide/install.md
+++ b/docs/langs/en/guide/install.md
@@ -15,17 +15,34 @@ yarn add fusion-ui-vue
 pnpm add fusion-ui-vue
 ```
 
-## On-demand Import
+## Full Import
 
-You can choose one of the ways to introduce FusionUI components on demand.
+By fully importing FusionUI components, the package size will increase.
+
+```main.ts```
+```ts
+import { createApp } from 'vue'
+import fusionUi from 'fusion-ui-vue'
+import 'fusion-ui-vue/dist/styles/index.css'
+import App from './App.vue'
+
+const app = createApp(App)
+app.use(fusionUi)
+app.mount('#app')
+```
+
+## On-demand Import
 
 * You can use the import statement to import the components you use.
   
-  ```ts
-  import { FnButton } from 'fusion-ui-vue'
-  ```
+```ts
+import { FnButton } from 'fusion-ui-vue'
+import 'fusion-ui-vue/dist/styles/base.css'
+import 'fusion-ui-vue/dist/styles/button/src/index.css'
+```
 
-* You need to use an additional plugin to import components you used. First you need to install [unplugin-vue-components](https://www.npmjs.com/package/unplugin-vue-components) and [unplugin-auto-import](https://www.npmjs.com/package/unplugin-auto-import).
+### Auto import
+* You need to use an additional plugin to import components you used. First you need to install [unplugin-vue-components](https://www.npmjs.com/package/unplugin-vue-components).
 
 ```shell
 npm install -D unplugin-vue-components
@@ -51,18 +68,4 @@ export default defineConfig({
   ],
 })
 ```
-
-```main.ts```
-
-```ts
-import { createApp } from 'vue'
-import fusionUi from 'fusion-ui-vue'
-import 'fusion-ui-vue/dist/styles/index.css'
-import App from './App.vue'
-
-const app = createApp(App)
-
-app.use(fusionUi)
-app.mount('#app')
-  ```
 Now you can start the project. Please check the document for the specific usage of each component.

--- a/docs/langs/zh/guide/install.md
+++ b/docs/langs/zh/guide/install.md
@@ -15,19 +15,36 @@ yarn add fusion-ui-vue
 pnpm add fusion-ui-vue
 ```
 
-## 按需引入
+## 完整引入
 
-您可以选择其中一种方式来按需引入 FusionUI 组件。
+完整导入 FusionUI 组件，包的体积会增大。
+
+```main.ts```
+```ts
+import { createApp } from 'vue'
+import fusionUi from 'fusion-ui-vue'
+import 'fusion-ui-vue/dist/styles/index.css'
+import App from './App.vue'
+
+const app = createApp(App)
+app.use(fusionUi)
+app.mount('#app')
+```
+
+
+## 按需引入
 
 * 您可以使用 `import` 语句来导入您使用的组件。
 
 
 ```ts
 import { FnButton } from 'fusion-ui-vue'
+import 'fusion-ui-vue/dist/styles/base.css'
+import 'fusion-ui-vue/dist/styles/button/src/index.css'
 ```
 
-
-* 您需可以使用一个额外的插件来导入您使用的组件。首先你需要安装 [unplugin-vue-components](https://www.npmjs.com/package/unplugin-vue-components)。
+### 自动导入
+* 您也可以使用一个额外的插件来自动导入您使用的组件，首先你需要安装 [unplugin-vue-components](https://www.npmjs.com/package/unplugin-vue-components)。
 
 ```shell
 npm install -D unplugin-vue-components
@@ -51,19 +68,5 @@ export default defineConfig({
   ],
 })
 ```
-
-```main.ts```
-  
-  ```ts
-import { createApp } from 'vue'
-import fusionUi from 'fusion-ui-vue'
-import 'fusion-ui-vue/dist/styles/index.css'
-import App from './App.vue'
-
-const app = createApp(App)
-
-app.use(fusionUi)
-app.mount('#app')
-```
-现在你可以启动项目了。 具体每个组件的使用方法,请查看文档。
+现在你可以启动项目了，具体每个组件的使用方法，请查看文档。
 


### PR DESCRIPTION
### 在阅读文档的时候遇到了一些问题
1.  大部分组件库的全局引入方法都在文档前面，一开始阅读文档以为没有这部分的说明，后面才发现在后面，因此这部分提前在前面可能会更友好。
2. 按需引入的方法说明不完整。
3. 英文文档有一处多余的部分。