### PR TITLE
feat: add action and actionEvent to the props of message

### DIFF
--- a/packages/components/alert/src/index.less
+++ b/packages/components/alert/src/index.less
@@ -6,7 +6,6 @@
   border-radius: var(--md-sys-shape-corner-extra-small-default-size);
   padding: 6px 16px;
   color: var(--fn-alert-on-color);
-  width: fit-content;
 
   .fn-alert--message {
     flex: 1;

--- a/packages/components/message/index.ts
+++ b/packages/components/message/index.ts
@@ -1,3 +1,3 @@
-export { default } from './src/index'
+export { default, default as FnMessage } from './src/index'
 export * from './src/message'
 export * from './src/index'

--- a/packages/components/message/src/index.jss.ts
+++ b/packages/components/message/src/index.jss.ts
@@ -2,8 +2,8 @@ import { css } from '@fusion-ui-vue/theme'
 import type { MessageProps } from './message'
 
 const useCss = (props: MessageProps) => {
-  const { position, transition } = props
-  const { x, y } = position
+  const { placement, transition } = props
+  const { x, y } = placement
 
   const transform = []
   let positionX

--- a/packages/components/message/src/index.tsx
+++ b/packages/components/message/src/index.tsx
@@ -7,7 +7,7 @@ import Notistack from './notistack.vue'
 import type { MessageProps } from './message'
 import useCss from './index.jss'
 
-export class FnMessage {
+export class FnMessageClass {
   private _rendered = false
   private readonly _body: HTMLElement = document.body
   private _notistack: VNode = (<Notistack />)
@@ -17,6 +17,10 @@ export class FnMessage {
     severity: 'info',
     icon: true,
     customIcon: undefined,
+    action: undefined,
+    actionEvent: (node: VNode) => {
+      this._removeMessage((node as any).id)
+    },
     content: '',
     duration: 2000,
     transition: 'all 0.5s ease',
@@ -51,6 +55,8 @@ export class FnMessage {
       title,
       content,
       customIcon,
+      action,
+      actionEvent,
       duration,
       position: _position,
       transition: _transition,
@@ -62,7 +68,9 @@ export class FnMessage {
     let timer: any = null
 
     const Alert = FnAlert as any
-    const Icon = customIcon ? (customIcon as any) : null
+    const Icon = customIcon as any
+    const Action = action as any
+    const id = generateId()
     const alertVNode = (
       <Alert
         {...alertProps}
@@ -70,7 +78,7 @@ export class FnMessage {
         onMouseleave={() => this._startTimer(alertVNode, duration)}
       >
         {{
-          icon: () => <Icon />,
+          icon: customIcon ? () => <Icon /> : undefined,
           default: () => (
             <>
               {!isEmpty(title) && (
@@ -85,10 +93,20 @@ export class FnMessage {
               {content}
             </>
           ),
+          action: action
+            ? (icon: any) => (
+                <Action
+                  {...icon}
+                  onClick={() =>
+                    actionEvent(alertVNode, this._removeMessage.bind(this))
+                  }
+                />
+              )
+            : undefined,
         }}
       </Alert>
     )
-    ;(alertVNode as any).id = generateId()
+    ;(alertVNode as any).id = id
     this._notistack.component?.exposed?.add(alertVNode)
 
     timer = this._startTimer(alertVNode, duration)
@@ -130,8 +148,8 @@ export class FnMessage {
   }
 
   static install(app: any) {
-    app.config.globalProperties.$message = singleton(FnMessage)
+    app.config.globalProperties.$message = singleton(FnMessageClass)
   }
 }
 
-export default singleton(FnMessage)
+export default singleton(FnMessageClass)

--- a/packages/components/message/src/index.tsx
+++ b/packages/components/message/src/index.tsx
@@ -24,7 +24,7 @@ export class FnMessageClass {
     content: '',
     duration: 2000,
     transition: 'all 0.5s ease',
-    position: {
+    placement: {
       x: 'right',
       y: 'top',
     },
@@ -58,7 +58,7 @@ export class FnMessageClass {
       action,
       actionEvent,
       duration,
-      position: _position,
+      placement: _placement,
       transition: _transition,
       ...alertProps
     } = {

--- a/packages/components/message/src/message.ts
+++ b/packages/components/message/src/message.ts
@@ -2,11 +2,11 @@ import type { Component, ExtractPropTypes, PropType, VNode } from 'vue'
 import { buildProps } from '@fusion-ui-vue/utils'
 import { alertProps } from '../../alert'
 
-const messageXPositions = ['left', 'center', 'right'] as const
-const messageYPositions = ['top', 'bottom'] as const
+const messageXPlacements = ['left', 'center', 'right'] as const
+const messageYPlacements = ['top', 'bottom'] as const
 export interface MessagePositions {
-  x: typeof messageXPositions[number]
-  y: typeof messageYPositions[number]
+  x: typeof messageXPlacements[number]
+  y: typeof messageYPlacements[number]
 }
 
 const { cs: _cs, ...restProps } = alertProps
@@ -40,7 +40,7 @@ export const messageProps = buildProps({
     type: String,
     default: 'all 0.5s ease',
   },
-  position: {
+  placement: {
     type: Object as PropType<Partial<MessagePositions>>,
     default: () => ({
       x: 'center',
@@ -48,8 +48,8 @@ export const messageProps = buildProps({
     }),
     validator: (val: Partial<MessagePositions>) => {
       const { x, y } = val
-      const xValid = x ? messageXPositions.includes(x) : true
-      const yValid = y ? messageYPositions.includes(y) : true
+      const xValid = x ? messageXPlacements.includes(x) : true
+      const yValid = y ? messageYPlacements.includes(y) : true
       return xValid && yValid
     },
   },

--- a/packages/components/message/src/message.ts
+++ b/packages/components/message/src/message.ts
@@ -1,4 +1,4 @@
-import type { Component, ExtractPropTypes, PropType } from 'vue'
+import type { Component, ExtractPropTypes, PropType, VNode } from 'vue'
 import { buildProps } from '@fusion-ui-vue/utils'
 import { alertProps } from '../../alert'
 
@@ -22,6 +22,15 @@ export const messageProps = buildProps({
   },
   customIcon: {
     type: Object as PropType<Component>,
+  },
+  action: {
+    type: Object as PropType<Component | VNode>,
+  },
+  actionEvent: {
+    type: Function as PropType<
+      (e: VNode, remove: (c: string | number) => void) => void
+    >,
+    default: () => {},
   },
   duration: {
     type: Number,

--- a/packages/theme/src/components/theme-provider.tsx
+++ b/packages/theme/src/components/theme-provider.tsx
@@ -61,15 +61,13 @@ export default defineComponent({
       emit('update:theme', theme.value)
     }
 
-    const warchTarget =
+    const watchTarget =
       props.theme.target === 'root'
         ? () => props.theme.mode
         : () => parentTheme.value?.mode ?? props.theme.mode
-    props.watcher ? props.watcher() : watch(warchTarget, toggleTheme)
+    props.watcher ? props.watcher() : watch(watchTarget, toggleTheme)
 
     useThemeProvider(theme as Ref<Theme>)
-
-    // defineExpose({ toggleTheme })
 
     const Comp = props.component as any
     return () =>

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -7,7 +7,7 @@ import {
   FnModal,
   FnMessage,
 } from '@fusion-ui-vue/components'
-import { DeleteFilled } from 'fusion-ui-iconify'
+import { DeleteFilled, VerifiedRound } from 'fusion-ui-iconify'
 import createTheme from '@fusion-ui-vue/theme'
 // import Badge from './components/Badge.vue'
 // import AvatarGroup from './components/AvatarGroup.vue'
@@ -50,14 +50,24 @@ watch(theme, () => ((window as any).theme = toRaw(theme.value)), {
       <fn-button
         @click="
           new FnMessage({
+            /**
+             * custom default props
+             * Can be override by the props passed in the method
+             */
             severity: 'success',
             variant: 'outlined',
-            position: { x: 'center' },
-          }).push({
-            content: 'this is a info message',
-            customIcon: DeleteFilled,
             action: (action: any) =>
               h(FnIconButton, { ...action }, () => h(DeleteFilled)),
+            placement: { x: 'center' },
+          }).push({
+            content: 'this is a info message',
+            customIcon: VerifiedRound,
+            action: (actionProps: any) =>
+              h(FnIconButton, actionProps, () => h(VerifiedRound)),
+            /**
+             * if the actionEvent is not set
+             * the default action event is to close the message
+             */
             actionEvent: (node, remove) => {
               new FnMessage().error({ content: 'error' })
               remove((node as any).id)

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 import '@fusion-ui-vue/components/modal/src/index.less' // 开发调试的样式
 import { ThemeProvider } from '@fusion-ui-vue/theme'
-import { FnButton, FnModal } from '@fusion-ui-vue/components'
+import {
+  FnButton,
+  FnIconButton,
+  FnModal,
+  FnMessage,
+} from '@fusion-ui-vue/components'
 import { DeleteFilled } from 'fusion-ui-iconify'
 import createTheme from '@fusion-ui-vue/theme'
-import { FnMessage } from '@fusion-ui-vue/components'
 // import Badge from './components/Badge.vue'
 // import AvatarGroup from './components/AvatarGroup.vue'
 // import ButtonGroup from './components/ButtonGroup.vue'
@@ -17,7 +21,7 @@ import { FnMessage } from '@fusion-ui-vue/components'
 // import LinkT from './components/Link.vue'
 // import FBA from './components/FBA.vue'
 // import Card from './components/Card.vue'
-import { toRaw, watch, ref } from 'vue'
+import { toRaw, watch, ref, h } from 'vue'
 
 const theme = createTheme()
 const open = ref(false)
@@ -38,17 +42,26 @@ watch(theme, () => ((window as any).theme = toRaw(theme.value)), {
 <template>
   <theme-provider :theme="theme">
     <!-- ------------------- Toggle between the light/dark mode ------------------- -->
-    <header>
+    <header class="content">
       <fn-button @click="changTheme">
-        <!-- @vue-skip -->
         {{ theme.mode }}
       </fn-button>
       <fn-button @click="open = !open"> open modal </fn-button>
       <fn-button
         @click="
-          new FnMessage({ severity: 'success', variant: 'outlined' }).push({
+          new FnMessage({
+            severity: 'success',
+            variant: 'outlined',
+            position: { x: 'center' },
+          }).push({
             content: 'this is a info message',
             customIcon: DeleteFilled,
+            action: (action: any) =>
+              h(FnIconButton, { ...action }, () => h(DeleteFilled)),
+            actionEvent: (node, remove) => {
+              new FnMessage().error({ content: 'error' })
+              remove((node as any).id)
+            },
           })
         "
       >


### PR DESCRIPTION
## Main changes explained:
- New feature: added `action` and `actionEvent` to the props of `Message`
- Renamed the Message's `prop.position` to `prop.placement`
- Fixed the typo in `ThemeProvider`