### PR TITLE
docs: menu

### DIFF
--- a/docs/example/card/anatomy-2.vue
+++ b/docs/example/card/anatomy-2.vue
@@ -10,12 +10,10 @@ const { MoreVertFilled, FavoriteFilled, ShareFilled } = pkg
       <template #avatar>
         <fn-avatar>R</fn-avatar>
       </template>
-      <fn-typography variant="title.medium" component="h1">
-        Health Essentials
-      </fn-typography>
-      <fn-typography component="h2" variant="title.small" cs="opacity: .5;">
-        November 14, 2023
-      </fn-typography>
+      <fn-headline-text
+        headline="Health Essentials"
+        supporting-text="November 14, 2023"
+      />
       <template #action>
         <fn-icon-button color="onSurfaceVariant" cs="opacity: .5;">
           <more-vert-filled />

--- a/docs/example/list/text-unselectable.vue
+++ b/docs/example/list/text-unselectable.vue
@@ -7,13 +7,13 @@
         <template #leading="{ avatar }">
           <fn-avatar v-bind="avatar">A</fn-avatar>
         </template>
-        <fn-list-item-text headline="Ullamco consectetur." />
+        <fn-headline-text headline="Ullamco consectetur." />
       </fn-list-item>
       <fn-list-item selectable>
         <template #leading="{ avatar }">
           <fn-avatar v-bind="avatar">B</fn-avatar>
         </template>
-        <fn-list-item-text
+        <fn-headline-text
           headline="In officia cupidatat!"
           supporting-text="Officia qui ea ex dolor."
         />
@@ -22,7 +22,7 @@
         <template #leading="{ avatar }">
           <fn-avatar v-bind="avatar">C</fn-avatar>
         </template>
-        <fn-list-item-text
+        <fn-headline-text
           headline="Brunch this weekend?"
           supporting-text="Ali Connors — I'll be in your neighborhood doing errands this…"
         />

--- a/docs/example/menu/basic.vue
+++ b/docs/example/menu/basic.vue
@@ -6,7 +6,12 @@ const anchor = ref<HTMLElement | MouseEvent | null>(null)
 
 <template>
   <fn-button @click="e => (anchor = e.currentTarget)">Show Menu</fn-button>
-  <fn-menu :open="Boolean(anchor)" :anchor="anchor" @close="anchor = null">
+  <fn-menu
+    keep-mounted
+    :open="Boolean(anchor)"
+    :anchor="anchor"
+    @close="anchor = null"
+  >
     <fn-list-item @click="anchor = null"> Copy </fn-list-item>
     <fn-list-item @click="anchor = null"> Cut </fn-list-item>
     <fn-list-item @click="anchor = null" disabled> Paste </fn-list-item>

--- a/docs/example/menu/basic.vue
+++ b/docs/example/menu/basic.vue
@@ -1,0 +1,17 @@
+<script lang="ts" setup>
+import { ref } from 'vue'
+
+const anchor = ref<HTMLElement | MouseEvent | null>(null)
+</script>
+
+<template>
+  <fn-button @click="e => (anchor = e.currentTarget)">Show Menu</fn-button>
+  <fn-menu :open="Boolean(anchor)" :anchor="anchor" @close="anchor = null">
+    <fn-list-item @click="anchor = null"> Copy </fn-list-item>
+    <fn-list-item @click="anchor = null"> Cut </fn-list-item>
+    <fn-list-item @click="anchor = null" disabled> Paste </fn-list-item>
+    <fn-divider component="li" />
+    <fn-list-item-header> Other actions </fn-list-item-header>
+    <fn-list-item @click="anchor = null"> Save </fn-list-item>
+  </fn-menu>
+</template>

--- a/docs/example/menu/context.vue
+++ b/docs/example/menu/context.vue
@@ -1,0 +1,80 @@
+<script lang="ts" setup>
+import { ref } from 'vue'
+import * as pkg from 'fusion-ui-iconify'
+
+const { ContentCopyFilled, ContentCutFilled, ContentPasteFilled, UndoFilled } =
+  pkg
+const anchor = ref<HTMLElement | MouseEvent | null>(null)
+const handleContextMenu = (e: MouseEvent) => {
+  e.preventDefault()
+  anchor.value = e
+}
+</script>
+
+<template>
+  <div @contextmenu="handleContextMenu">
+    <fn-typography>
+      Cupidatat Lorem proident esse enim ullamco non dolor fugiat ut. Officia
+      cillum sit ut incididunt laborum deserunt cupidatat labore laboris velit
+      deserunt eiusmod. Occaecat tempor dolore do ipsum eiusmod eiusmod
+      adipisicing nostrud labore. Fugiat tempor amet quis elit sit consequat
+      veniam. Deserunt in ipsum in est veniam sit dolor tempor cupidatat laboris
+      fugiat. Sint culpa culpa et consequat pariatur exercitation officia nisi
+      esse pariatur ad ipsum. Eiusmod deserunt est ea mollit veniam. Ea proident
+      ea duis veniam eu elit commodo voluptate mollit aliquip.
+    </fn-typography>
+  </div>
+  <fn-menu
+    keep-mounted
+    :open="Boolean(anchor)"
+    :anchor="anchor"
+    :placement="{ x: 'right' }"
+    cs="width: 200px;"
+    @close="anchor = null"
+  >
+    <fn-list-item>
+      <template #leading="{ icon }">
+        <content-copy-filled v-bind="icon" />
+      </template>
+      Copy
+      <template #trailing>
+        <fn-typography variant="label.large" cs="opacity: 0.6;">
+          ⌘X
+        </fn-typography>
+      </template>
+    </fn-list-item>
+    <fn-list-item>
+      <template #leading="{ icon }">
+        <content-cut-filled v-bind="icon" />
+      </template>
+      Cut
+      <template #trailing>
+        <fn-typography variant="label.large" cs="opacity: 0.6;">
+          ⌘C
+        </fn-typography>
+      </template>
+    </fn-list-item>
+    <fn-list-item disabled>
+      <template #leading="{ icon }">
+        <content-paste-filled v-bind="icon" />
+      </template>
+      Paste
+      <template #trailing>
+        <fn-typography variant="label.large" cs="opacity: 0.6;">
+          ⌘V
+        </fn-typography>
+      </template>
+    </fn-list-item>
+    <fn-list-item>
+      <template #leading="{ icon }">
+        <undo-filled v-bind="icon" />
+      </template>
+      Undo
+      <template #trailing>
+        <fn-typography variant="label.large" cs="opacity: 0.6;">
+          ⌘Z
+        </fn-typography>
+      </template>
+    </fn-list-item>
+  </fn-menu>
+</template>

--- a/docs/example/menu/placement.vue
+++ b/docs/example/menu/placement.vue
@@ -1,0 +1,52 @@
+<script lang="ts" setup>
+import { ref } from 'vue'
+import type { PopoverPlacements } from 'fusion-ui-vue'
+
+const anchor = ref<HTMLElement | MouseEvent | null>(null)
+const placement = ref<PopoverPlacements>({ x: 'right', y: 'top' })
+const handleClick = (e: MouseEvent, p: PopoverPlacements) => {
+  anchor.value = e.currentTarget as HTMLElement
+  placement.value = p
+}
+</script>
+
+<template>
+  <fn-button
+    variant="outlined"
+    @click="e => handleClick(e, { x: 'right', y: 'top' })"
+  >
+    Top right
+  </fn-button>
+  <fn-button
+    variant="outlined"
+    @click="e => handleClick(e, { x: 'left', y: 'top' })"
+  >
+    Top left
+  </fn-button>
+  <fn-button
+    variant="outlined"
+    @click="e => handleClick(e, { x: 'right', y: 'bottom' })"
+  >
+    Bottom right
+  </fn-button>
+  <fn-button
+    variant="outlined"
+    @click="e => handleClick(e, { x: 'left', y: 'bottom' })"
+  >
+    Bottom left
+  </fn-button>
+  <fn-menu
+    :open="Boolean(anchor)"
+    :placement="placement"
+    :anchor="anchor"
+    cs="width: 200px;"
+    @close="anchor = null"
+  >
+    <fn-list-item @click="anchor = null"> Copy </fn-list-item>
+    <fn-list-item @click="anchor = null"> Cut </fn-list-item>
+    <fn-list-item disabled @click="anchor = null"> Paste </fn-list-item>
+    <fn-divider component="li" />
+    <fn-list-item-header> Other actions </fn-list-item-header>
+    <fn-list-item @click="anchor = null"> Save </fn-list-item>
+  </fn-menu>
+</template>

--- a/docs/example/menu/placement.vue
+++ b/docs/example/menu/placement.vue
@@ -36,6 +36,7 @@ const handleClick = (e: MouseEvent, p: PopoverPlacements) => {
     Bottom left
   </fn-button>
   <fn-menu
+    keep-mounted
     :open="Boolean(anchor)"
     :placement="placement"
     :anchor="anchor"

--- a/docs/example/menu/sublist.vue
+++ b/docs/example/menu/sublist.vue
@@ -9,7 +9,12 @@ const showSublist = ref(false)
 
 <template>
   <fn-button @click="e => (anchor = e.currentTarget)">Show Menu</fn-button>
-  <fn-menu :open="Boolean(anchor)" :anchor="anchor" @close="anchor = null">
+  <fn-menu
+    keep-mounted
+    :open="Boolean(anchor)"
+    :anchor="anchor"
+    @close="anchor = null"
+  >
     <fn-list-item> Copy </fn-list-item>
     <fn-list-item
       @mouseenter="showSublist = true"

--- a/docs/example/menu/sublist.vue
+++ b/docs/example/menu/sublist.vue
@@ -1,0 +1,28 @@
+<script lang="ts" setup>
+import { ref } from 'vue'
+import * as pkg from 'fusion-ui-iconify'
+
+const { ArrowRightFilled } = pkg
+const anchor = ref<HTMLElement | MouseEvent | null>(null)
+const showSublist = ref(false)
+</script>
+
+<template>
+  <fn-button @click="e => (anchor = e.currentTarget)">Show Menu</fn-button>
+  <fn-menu :open="Boolean(anchor)" :anchor="anchor" @close="anchor = null">
+    <fn-list-item> Copy </fn-list-item>
+    <fn-list-item
+      @mouseenter="showSublist = true"
+      @mouseleave="showSublist = false"
+    >
+      More
+      <template #trailing="icon">
+        <arrow-right-filled v-bind="icon" />
+      </template>
+      <fn-list v-if="showSublist" cs="width: 100px;" sublist>
+        <fn-list-item> Cut </fn-list-item>
+        <fn-list-item> Paste </fn-list-item>
+      </fn-list>
+    </fn-list-item>
+  </fn-menu>
+</template>

--- a/docs/langs/en/components/list.md
+++ b/docs/langs/en/components/list.md
@@ -29,7 +29,7 @@ Use `indent` prop enables a list item that does not have a leading icon or avata
 
 Set `selectable=false` to make the items it unselectable. Also, you can set for specific `ListItem`.
 
-The `ListItemText` component help to display the headline and supporting text.
+The `HeadlineText` component help to display the headline and supporting text.
 
 <demo src="../../../example/list/text-unselectable.vue" />
 

--- a/docs/langs/en/components/menu.md
+++ b/docs/langs/en/components/menu.md
@@ -7,8 +7,28 @@ lang: en
 
 Menus display a list of choices on a temporary surface.
 
-::: info
+::: info Notice
 The `Menu` is build with `Popover` and `List` components
 :::
 
-`🔜 Coming soom...`
+## Basic usage
+
+The `anchor` help the menu to locate itself, and the `open` is to switch the on/off status of the menu.
+
+<demo src="../../../example/menu/basic.vue" />
+
+## Placement
+
+The `placement` passed by prop will be consider first when locate the menu.
+
+<demo src="../../../example/menu/placement.vue" />
+
+::: warning Warning
+The final placement **may not** be the same as the prop passed to the component. It will calculate the availabe space when open the menu.
+:::
+
+## Sublist
+
+The `sublist` prop on the `List` used to locate the expanded sublist.
+
+<demo src="../../../example/menu/sublist.vue" />

--- a/docs/langs/en/components/menu.md
+++ b/docs/langs/en/components/menu.md
@@ -32,3 +32,9 @@ The final placement **may not** be the same as the prop passed to the component.
 The `sublist` prop on the `List` used to locate the expanded sublist.
 
 <demo src="../../../example/menu/sublist.vue" />
+
+## Context menu
+
+The `anchor` also can be the `MouseEvent`. This will help to build the custom context menu. (Right click to open)
+
+<demo src="../../../example/menu/context.vue" />

--- a/docs/langs/zh/components/list.md
+++ b/docs/langs/zh/components/list.md
@@ -29,7 +29,7 @@ lang: zh
 
 将 `selectable=false` 设置为使项目不可选择。此外，您还可以为特定的 `ListItem` 进行设置。
 
-`ListItemText` 组件可用于显示标题和支持文本。
+`HeadlineText` 组件可用于显示标题和支持文本。
 
 <demo src="../../../example/list/text-unselectable.vue" />
 

--- a/packages/components/headline-text/index.ts
+++ b/packages/components/headline-text/index.ts
@@ -1,0 +1,8 @@
+import { withInstall } from '../install'
+import HeadlineText from './src/index.vue'
+
+export const FnHeadlineText = withInstall(HeadlineText, 'FnHeadlineText')
+FnHeadlineText.name = 'FnHeadlineText'
+export default FnHeadlineText
+export * from './src/headline-text'
+export type ListItemTextInstance = InstanceType<typeof HeadlineText>

--- a/packages/components/headline-text/src/headline-text.ts
+++ b/packages/components/headline-text/src/headline-text.ts
@@ -1,7 +1,7 @@
 import { buildProps } from '@fusion-ui-vue/utils'
 import type { ExtractPropTypes } from 'vue'
 
-export const listItemTextProps = buildProps({
+export const headlineTextProps = buildProps({
   headline: {
     type: String,
     required: true,
@@ -11,4 +11,4 @@ export const listItemTextProps = buildProps({
   },
 })
 
-export type ListItemTextProps = ExtractPropTypes<typeof listItemTextProps>
+export type HeadlineTextProps = ExtractPropTypes<typeof headlineTextProps>

--- a/packages/components/headline-text/src/index.vue
+++ b/packages/components/headline-text/src/index.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
 import FnTypography from '../../typography'
-import { listItemTextProps } from './list-item-text'
+import { headlineTextProps } from './headline-text'
 
-defineProps(listItemTextProps)
+defineProps(headlineTextProps)
 defineOptions({ inheritAttrs: false })
 </script>
 

--- a/packages/components/index.ts
+++ b/packages/components/index.ts
@@ -36,10 +36,10 @@ import FnPopover from './popover'
 import FnDivider from './divider'
 import FnList from './list'
 import FnListItem from './list-item'
-import FnListItemText from './list-item-text'
 import FnListHeader from './list-item-header'
 import FnCollapse from './collapse'
 import FnMenu from './menu'
+import FnHeadlineText from './headline-text'
 export * from './button-base'
 export * from './avatar-group'
 export * from './button'
@@ -78,10 +78,10 @@ export * from './popover'
 export * from './divider'
 export * from './list'
 export * from './list-item'
-export * from './list-item-text'
 export * from './list-item-header'
 export * from './collapse'
 export * from './menu'
+export * from './headline-text'
 
 export const components = [
   FnButtonBase,
@@ -122,10 +122,10 @@ export const components = [
   FnDivider,
   FnList,
   FnListItem,
-  FnListItemText,
   FnListHeader,
   FnCollapse,
   FnMenu,
+  FnHeadlineText,
 ] as any[]
 
 const CK = {

--- a/packages/components/list-item-text/index.ts
+++ b/packages/components/list-item-text/index.ts
@@ -1,8 +1,0 @@
-import { withInstall } from '../install'
-import ListItemText from './src/index.vue'
-
-export const FnListItemText = withInstall(ListItemText, 'FnListItemText')
-FnListItemText.name = 'FnListItemText'
-export default FnListItemText
-export * from './src/list-item-text'
-export type ListItemTextInstance = InstanceType<typeof ListItemText>

--- a/packages/components/modal/src/index.vue
+++ b/packages/components/modal/src/index.vue
@@ -31,6 +31,7 @@ const handleClick = () => {
   <teleport to="body">
     <transition name="fade">
       <div
+        v-if="$props.keepMounted || open"
         v-show="open"
         :class="[ns.b(), open ? ns.m('open') : '']"
         v-bind="$attrs"

--- a/packages/components/modal/src/modal.ts
+++ b/packages/components/modal/src/modal.ts
@@ -11,6 +11,10 @@ export const modalProps = buildProps({
     type: Boolean,
     default: true,
   },
+  keepMounted: {
+    type: Boolean,
+    default: false,
+  },
   cs: {
     type: [Object, String],
   },

--- a/packages/components/popover/src/index.vue
+++ b/packages/components/popover/src/index.vue
@@ -160,6 +160,7 @@ watch(
 
 <template>
   <fn-modal
+    :keep-mounted="$props.keepMounted"
     :model-value="$props.open"
     :backdrop="$props.backdrop"
     @click="$emit('close')"

--- a/packages/components/popover/src/popover.ts
+++ b/packages/components/popover/src/popover.ts
@@ -24,8 +24,9 @@ export const popoverProps = buildProps({
     type: Boolean,
     default: false,
   },
-  cs: {
-    type: [Object, String],
+  keepMounted: {
+    type: Boolean,
+    default: false,
   },
   placement: {
     type: Object as PropType<Partial<PopoverPlacements>>,
@@ -39,6 +40,9 @@ export const popoverProps = buildProps({
       const yValid = y ? popoverYPlacements.includes(y) : true
       return xValid && yValid
     },
+  },
+  cs: {
+    type: [Object, String],
   },
 })
 

--- a/playground/src/components/List.vue
+++ b/playground/src/components/List.vue
@@ -15,7 +15,7 @@ import {
   FnListItemHeader,
   FnBadge,
   FnAvatar,
-  FnListItemText,
+  FnHeadlineText,
   FnButton,
   FnMenu,
 } from '@fusion-ui-vue/components'

--- a/playground/src/components/List.vue
+++ b/playground/src/components/List.vue
@@ -157,7 +157,7 @@ const handleClick = (num: number) => {
             <template #leading="{ avatar }">
               <fn-avatar cs="margin-bottom: auto;" v-bind="avatar">A</fn-avatar>
             </template>
-            <fn-list-item-text
+            <fn-headline-text
               headline="Brunch this weekend?"
               supporting-text="Ali Connors — I'll be in your neighborhood doing errands this…"
             />
@@ -166,7 +166,7 @@ const handleClick = (num: number) => {
             <template #leading="{ avatar }">
               <fn-avatar v-bind="avatar">A</fn-avatar>
             </template>
-            <fn-list-item-text
+            <fn-headline-text
               headline="Brunch this weekend?"
               supporting-text="Ali Connors"
             />


### PR DESCRIPTION
## Main changes explained:
- Updated the docs for `Menu`
- Renamed `ListItemText` to `HeadlineText`
- New feature
  - Added `keepMounted` prop to `Modal` and `Popover`